### PR TITLE
fix: write args.gn before calling gn gen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ pub fn maybe_gen(root: &str, debug_args: &str, release_args: &str) -> PathBuf {
   let gn_out_dir = out_dir().join("gn_out");
 
   if !gn_out_dir.exists() {
+    let args = if is_debug() { debug_args } else { release_args };
+    write_args(&gn_out_dir.join("args.gn"), args);
+
     let status = Command::new(gn_path())
       .arg(format!("--root={}", root))
       .arg("gen")
@@ -31,9 +34,6 @@ pub fn maybe_gen(root: &str, debug_args: &str, release_args: &str) -> PathBuf {
       .status()
       .expect("gn gen failed");
     assert!(status.success());
-
-    let args = if is_debug() { debug_args } else { release_args };
-    write_args(&gn_out_dir.join("args.gn"), args);
   }
   return gn_out_dir;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub fn maybe_gen(root: &str, debug_args: &str, release_args: &str) -> PathBuf {
 
   if !gn_out_dir.exists() {
     let args = if is_debug() { debug_args } else { release_args };
-    write_args(&gn_out_dir.join("args.gn"), args);
+    write_args(&gn_out_dir, args);
 
     let status = Command::new(gn_path())
       .arg(format!("--root={}", root))
@@ -61,7 +61,8 @@ pub fn build(target: &str) {
 }
 
 fn write_args(path: &PathBuf, contents: &str) {
-  fs::write(path, contents).expect("Unable to write args.gn");
+  fs::create_dir_all(path).expect("Unable to create gn_out directory");
+  fs::write(path.join("args.gn"), contents).expect("Unable to write args.gn");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This should fix (only the issue described in this comment) https://github.com/denoland/deno/pull/2640#issuecomment-512516678.

Edit: Ok, it's not quite that easy, because the `gn_out` directory doesn't exist yet in that case...

Sorry, but this is the first time I'm writing something in rust.