### PR TITLE
fix ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 sudo: false
+dist: xenial
 language: c++
 git:
   depth: 1
@@ -34,19 +35,21 @@ install:
   rm -rf "$RUSTUP_HOME"tmp
   rm -rf "$RUSTUP_HOME"toolchains/*/etc
   rm -rf "$RUSTUP_HOME"toolchains/*/share
+- export NINJA=$HOME/ninja/ninja && export GN=$HOME/gn/out/gn
 - |-
   # Build Ninja
   if [ ! -d ninja ]; then
-    git clone https://github.com/ninja-build/ninja.git --depth=1
-    (cd ninja && python ./bootstrap.py)
+    git clone https://github.com/ninja-build/ninja.git --depth=1 $HOME/ninja
+    cd $HOME/ninja
+    python ./bootstrap.py
   fi
 - |-
   # Build GN
   if [ ! -d gn ]; then
-    git clone https://gn.googlesource.com/gn
-    cd gn
+    git clone https://gn.googlesource.com/gn $HOME/gn
+    cd $HOME/gn
     python build/gen.py
-    ninja -C out gn
+    $NINJA -C out gn
   fi
 
 before_script:
@@ -57,4 +60,5 @@ before_script:
 - set -e
 
 script:
+- cd $TRAVIS_BUILD_DIR
 - cargo test --all -vv

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,10 @@ steps:
     displayName: Install rust
 
   - script: |
-      sudo apt install -y ninja-build
+      git clone https://github.com/ninja-build/ninja.git --depth=1
+      cd ninja
+      python ./bootstrap.py
+      echo "##vso[task.prependpath]$(system.defaultWorkingDirectory)/ninja"
     displayName: Install ninja
 
   - script: |


### PR DESCRIPTION
* travis:
    * need to set $GN and $NINJA because we don't install them to a location in the $PATH
    * clone and build them actual inside $HOME and not at root level (the cwd in the install step) 
        * this also fixes caching them in travis
    * use ubuntu xenial (16.04) on travis too, because the gcc on trusty (14.04) is too old to build gn
        * alternatively we could use bionic (18.04) and could get a recent enough ninja (1.7.2) from apt there
* azure: 
    * ninja from ubuntu 16.04 apt is way to old (1.5.2), so we have to build a recent version from source here too

*Note: This is targeting the `v11` branch from #13*
